### PR TITLE
feat: colore les messages sûrs de $prez

### DIFF
--- a/src/cog_presentation/cog.py
+++ b/src/cog_presentation/cog.py
@@ -8,7 +8,7 @@ from urpy import utils, lcl, MyBot
 import cog_presentation.info
 from cog_presentation import strings
 from cog_presentation import settings
-from urpy.utils import error_log
+from urpy.utils import error_log, colored_message, SUCCESS_COLOR, ERROR_COLOR
 import pickle
 import os
 from pathlib import Path
@@ -45,7 +45,7 @@ class Presentation(urpy.MyCog):
         # TODO fix contexts shenanigans
         # checks that $cal is called in the right place
         if isinstance(ctx.channel, discord.DMChannel):
-            await base_ctx.send(_(strings.on_prez_dm_channel))
+            await base_ctx.send(colored_message(_(strings.on_prez_dm_channel), ERROR_COLOR))
         elif isinstance(ctx.channel, discord.TextChannel):
             anncmnt_channel = discord.utils.get(ctx.guild.channels, name=settings.announcement_channel)
             if not anncmnt_channel:
@@ -78,11 +78,11 @@ class Presentation(urpy.MyCog):
                 except discord.errors.Forbidden:
                     error_log("Impossible d'obtenir les webhooks.",  # TODO change to english
                               "Le bot nécessite la permission de gérer les webhooks")
-                    await ctx.author.send(strings.on_permission_error)
+                    await ctx.author.send(colored_message(strings.on_permission_error, ERROR_COLOR))
                 except IndexError:
                     await ctx.send(_(strings.on_prez_webhook_not_found.format(channel=settings.announcement_channel)))
                 else:
-                    await ctx.send(_(strings.on_prez))
+                    await ctx.send(colored_message(_(strings.on_prez), SUCCESS_COLOR))
                     await ctx.author.send(
                         strings.on_prez_link.format(link=f"http://presentation.unionrolistes.fr"))
                             #?webhook={webhook.url}"))

--- a/src/cog_presentation/info/credits.txt
+++ b/src/cog_presentation/info/credits.txt
@@ -1,2 +1,3 @@
 Lyss <delpratflo@cy-tech.fr>
 Maestro#8364 <yoyou20@hotmail.fr>
+Mortifia


### PR DESCRIPTION
## Résumé

- Réutilise `colored_message`/`SUCCESS_COLOR`/`ERROR_COLOR` de `Bot_Base.src.urpy.utils` pour colorer les messages de `$prez`, en cohérence avec la coloration déjà en place sur `$help`/`$version`/`$credit`/`$lang`.
- `on_prez_link` (contient une URL) et `on_prez_channel_not_found`/`on_prez_webhook_not_found` (markdown gras/italique existant) restent volontairement en texte brut : un code block ANSI casserait leur rendu.

**⚠️ Dépend de** UnionRolistes/Bot_Base#84 — les helpers de coloration doivent être mergés dans Bot_Base avant que ce fix ait un effet réel.

Closes #77

## Test plan

- [ ] Après merge de Bot_Base#84, déployer sur l'instance dev et vérifier visuellement `$prez`.