### PR TITLE
fix($prez): inclure le webhook dans le lien DM

### DIFF
--- a/src/cog_presentation/cog.py
+++ b/src/cog_presentation/cog.py
@@ -84,8 +84,7 @@ class Presentation(urpy.MyCog):
                 else:
                     await ctx.send(colored_message(_(strings.on_prez), SUCCESS_COLOR))
                     await ctx.author.send(
-                        strings.on_prez_link.format(link=f"http://presentation.unionrolistes.fr"))
-                            #?webhook={webhook.url}"))
+                        strings.on_prez_link.format(link=f"http://presentation.unionrolistes.fr?webhook={webhook.url}"))
 
     @staticmethod
     def get_credits():


### PR DESCRIPTION
## Contexte

Bug pré-existant trouvé en testant le vrai flux OAuth + webhook de bout
en bout (pas de mock) sur `presentation.unionrolistes.fr`, dans le cadre
de la migration décrite dans #79/#80.

## Bug

`$prez` (`cog.py`) est censé envoyer un lien du type
`http://presentation.unionrolistes.fr?webhook={webhook.url}`, mais le
paramètre `?webhook=` était laissé en commentaire (reliquat d'une
migration précédente vers ce mécanisme — l'ancien fallback par fichier
pickle `whPrez` est déjà mort côté CGI/PHP, qui ne lit plus que
`webhook_url` depuis le POST du formulaire).

Résultat : le lien réellement envoyé ne portait jamais le webhook,
`index.php` ne pouvait donc jamais peupler `$_SESSION['webhook']`, et la
soumission du formulaire échouait systématiquement avec `?error=envoi`,
quel que soit le reste du flux (OAuth, champs, etc.).

## Fix

Une ligne : décommenter/corriger le paramètre `?webhook={webhook.url}`
dans le lien envoyé en DM.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>