### PR TITLE
feat: rejoint traefik-public, labels de routage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,25 @@ services:
       dockerfile: Dockerfile
     container_name: web-presentation
     restart: unless-stopped
+    # Port encore publié pendant la préparation de la bascule Traefik :
+    # Apache en dépend tant que la bascule finale n'a pas eu lieu. Retiré
+    # une fois Apache arrêté (Traefik devient l'unique point d'entrée).
     ports:
       - "8083:80"
+    networks:
+      - default
+      - traefik-public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.web-presentation.rule=Host(`presentation.unionrolistes.fr`)"
+      - "traefik.http.routers.web-presentation.entrypoints=websecure"
+      - "traefik.http.routers.web-presentation.tls.certresolver=le"
+      - "traefik.http.services.web-presentation.loadbalancer.server.port=80"
     environment:
       - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID}
       - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET}
       - DISCORD_REDIRECT_URI=${DISCORD_REDIRECT_URI}
+
+networks:
+  traefik-public:
+    external: true


### PR DESCRIPTION
Prépare la bascule Traefik (remplace Apache comme ingress unique pour les domaines *.unionrolistes.fr). Découverte par labels Docker plutôt qu'un vhost Apache séparé à maintenir.

Le port publié (8083) reste en place tant qu'Apache en a besoin — retiré dans une PR de suivi une fois la bascule finale (Apache arrêté) confirmée.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>